### PR TITLE
Checkout 2.0 branch rather than a specific rc

### DIFF
--- a/nightly
+++ b/nightly
@@ -63,7 +63,7 @@ cd /data/project/pywikibot/public_html/
 rm -rf /data/project/pywikibot/public_html/core_stable
 git clone https://gerrit.wikimedia.org/r/pywikibot/core.git core_stable
 cd /data/project/pywikibot/public_html/core_stable/
-git checkout tags/2.0rc3 -b core_stable
+git checkout 2.0 -b core_stable
 cd /data/project/pywikibot/public_html/core_stable/externals
 rm -rf httplib2
 git clone https://gerrit.wikimedia.org/r/pywikibot/externals/httplib2.git


### PR DESCRIPTION
In this way, we can backport patches without immediately providing a new rc, and people using the nightly can already use it.
